### PR TITLE
Add one-indexed values for video names

### DIFF
--- a/src/controller/settings.coffee
+++ b/src/controller/settings.coffee
@@ -74,7 +74,9 @@ class SettingsController
       section: section.title,
       lecture: lecture.title,
       sectionIndex: sectionIndex,
-      lectureIndex: lectureIndex
+      lectureIndex: lectureIndex,
+      sectionNumber: sectionIndex + 1,
+      lectureNumber: lectureIndex + 1
 
   selected: (value) ->
     for section in @incomingTasks.sections


### PR DESCRIPTION
This allows users to create video titles as they would have been created if you had just normally downloaded them, as was requested in issue #3.

It adds two new variables for interpolation, sectionNumber and lectureNumber. These values are equivalent to their corresponding indices except that they're incremented by one.

The original video title with this commit would be expressed like this:

```
#{sectionNumber} - #{lectureNumber} - #{lecture}
```

This is most suitable alongside my other pull request, #7, because without specifying a subdirectory for the downloaded files, it will be hard to distinguish between different courses in video files downloaded to the user's downloads folder.
